### PR TITLE
Fix unit offset bug

### DIFF
--- a/src/unitpy/core.py
+++ b/src/unitpy/core.py
@@ -261,7 +261,7 @@ class Unit(metaclass=MetaUnit):
         return self._base_unit
 
     def to_base_value(self, value: int | float) -> int | float:
-        return self.multiplier * value + self.offset
+        return self.multiplier * ( value + self.offset )
 
     def from_base_value(self, value: int | float) -> int | float:
         value = value / self.multiplier - self.offset

--- a/src/unitpy/definitions/unit_NIST.py
+++ b/src/unitpy/definitions/unit_NIST.py
@@ -428,8 +428,8 @@ units_NIST = {
     "temperature": {
         "base": BaseSet(kelvin=1),
         "Fahrenheit": {
-            "multiplier": 1.8,
-            "offset": -459.67,
+            "multiplier": 5/9,
+            "offset": 459.67,
             "abbr": "degF",
             "additional_labels": ["fahrenheit"]
         },

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -33,6 +33,12 @@ cases = (
     ("1 kg", "35.274 oz"),
     ("1 kg", "0.000984207 ton_long"),
 
+    # temperature
+    ("0 degC", "32 degF"),
+    ("50 degF", "10 degC"),
+    ("0 degK", "-273.15 degC"),
+    ("-459.67 degF", "0 degK"),
+
 )
 
 


### PR DESCRIPTION
First and foremost: Amazing package - thanks for sharing this!

Please consider accepting this PR to 
1) fix `to_base_value` formula: The bug only becomes apparent when dealing with units that require multiplier AND offset for conversion, for instance, when converting degree Celsius to degree Fahrenheit.
2) fix the multiplier and offset for unit Fahrenheit

I also extended the conversion unit tests.